### PR TITLE
Fixed path in code and in tests to work on windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,10 @@ var PluginError = gutil.PluginError;
 module.exports = function(options) {
   options = options || {};
 
+  function normalizeTemplateName(name) {
+    return name.replace('\\', '/');
+  }
+
   function transform(file, encoding, next) {
 
     if(file.isNull()) {
@@ -22,7 +26,7 @@ module.exports = function(options) {
     var module = typeof options.module === 'function' ? options.module.call(file, name) : (options.module || 'ngTemplates');
     var standalone = options.standalone ? ', []' : '';
     var header = gutil.template('angular.module(\'<%= module %>\'<%= standalone %>).run([\'$templateCache\', function($templateCache) {', {module: module, standalone: standalone, file: ''});
-    var content = gutil.template('  $templateCache.put(\'<%= name %>\', \'<%= contents %>\');', {name: name, contents: contents, file: ''});
+    var content = gutil.template('  $templateCache.put(\'<%= name %>\', \'<%= contents %>\');', {name: normalizeTemplateName(name), contents: contents, file: ''});
     var footer = '}]);';
 
     file.contents = new Buffer(['\'use strict\';', header, content, footer].join('\n\n'));

--- a/test/main.js
+++ b/test/main.js
@@ -9,16 +9,22 @@ require('mocha');
 
 describe('gulp-ngtemplate', function() {
 
-  var defaults = {
-    path: '/tmp/test/fixture/file.js',
-    cwd: '/tmp/test/',
-    base: '/tmp/test/fixture/'
-  };
+  var defaults;
 
   beforeEach(function() {
+    defaults = {
+      path: '/tmp/test/fixture/file.js',
+      cwd: '/tmp/test/',
+      base: '/tmp/test/fixture/'
+    };
   });
 
   describe('ngtemplate()', function() {
+    var testfilePath;
+
+    beforeEach(function() {
+      testFilePath = path.normalize('/tmp/test/fixture/file.js');
+    });
 
     it('should properly compile a template', function(done) {
 
@@ -33,7 +39,7 @@ describe('gulp-ngtemplate', function() {
         should.exist(newFile.relative);
         should.exist(newFile.contents);
         should.equal(newFile.contents.toString(), ['\'use strict\';', header, '  $templateCache.put(\'file.js\', \'<div>foo</div>\');', footer].join('\n\n'));
-        newFile.path.should.equal('/tmp/test/fixture/file.js');
+        newFile.path.should.equal(testFilePath);
         newFile.relative.should.equal('file.js');
       });
       stream.once('end', done);
@@ -55,7 +61,7 @@ describe('gulp-ngtemplate', function() {
         should.exist(newFile.relative);
         should.exist(newFile.contents);
         should.equal(newFile.contents.toString(), ['\'use strict\';', header, '  $templateCache.put(\'file.js\', \'<div>foo</div>\');', footer].join('\n\n'));
-        newFile.path.should.equal('/tmp/test/fixture/file.js');
+        newFile.path.should.equal(testFilePath);
         newFile.relative.should.equal('file.js');
       });
       stream.once('end', done);
@@ -63,6 +69,30 @@ describe('gulp-ngtemplate', function() {
       stream.end();
 
     });
+
+    it('should generate a os independent template key', function(done) {
+
+       defaults.path = '/tmp/test/fixture/extra/file.js';
+       testFilePath = path.normalize(defaults.path);
+       var testFileRelative = path.relative(defaults.base, defaults.path);
+       var fixture = new File(extend({contents: new Buffer('<div>foo</div>')}, defaults));
+       var header = 'angular.module(\'ngTemplates\').run([\'$templateCache\', function($templateCache) {';
+       var footer = '}]);';
+
+       var stream = ngtemplate();
+       stream.on('data', function(newFile){
+         should.exist(newFile);
+         should.exist(newFile.path);
+         should.exist(newFile.relative);
+         should.exist(newFile.contents);
+         should.equal(newFile.contents.toString(), ['\'use strict\';', header, '  $templateCache.put(\'extra/file.js\', \'<div>foo</div>\');', footer].join('\n\n'));
+         newFile.path.should.equal(testFilePath);
+         newFile.relative.should.equal(testFileRelative);
+       });
+       stream.once('end', done);
+       stream.write(fixture);
+       stream.end();
+     });
 
     it('should support module option as a function', function(done) {
 
@@ -77,7 +107,7 @@ describe('gulp-ngtemplate', function() {
         should.exist(newFile.relative);
         should.exist(newFile.contents);
         should.equal(newFile.contents.toString(), ['\'use strict\';', header, '  $templateCache.put(\'file.js\', \'<div>foo</div>\');', footer].join('\n\n'));
-        newFile.path.should.equal('/tmp/test/fixture/file.js');
+        newFile.path.should.equal(testFilePath);
         newFile.relative.should.equal('file.js');
       });
       stream.once('end', done);
@@ -99,7 +129,7 @@ describe('gulp-ngtemplate', function() {
         should.exist(newFile.relative);
         should.exist(newFile.contents);
         should.equal(newFile.contents.toString(), ['\'use strict\';', header, '  $templateCache.put(\'file.js\', \'<div>foo</div>\');', footer].join('\n\n'));
-        newFile.path.should.equal('/tmp/test/fixture/file.js');
+        newFile.path.should.equal(testFilePath);
         newFile.relative.should.equal('file.js');
       });
       stream.once('end', done);


### PR DESCRIPTION
Greetings, 
                  I took the liberty to fix some tests that would not run properly on windows due to some path inconsistencies.

You will also find in this PR a small modification to the code that will 'normalize' the template key name. This is to solve a problem on windows where the template key would be `mgcrea\typename` instead of `mgcrea/typename`.

Feel free to comment on any modification you'd want me to add to make this PR 'mergable'. This is something I need in order to push another PR on angular-strap.

Thank you :)
