### PR TITLE
Fix issue with normalizeTemplateName on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = function(options) {
   options = options || {};
 
   function normalizeTemplateName(name) {
-    return name.replace('\\', '/');
+    return name.replace(/\\/g, '/');
   }
 
   function transform(file, encoding, next) {


### PR DESCRIPTION
The function "replace" only replaces the first occurrence of the string passed in parameter, therefore for templates containing more than one sublevel, only the first backslash is replaced, resulting in templateCache's keys not having the right identifier.
